### PR TITLE
Detected objects with feature visualization

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/CMakeLists.txt
+++ b/common/autoware_auto_perception_rviz_plugin/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(Qt5 REQUIRED COMPONENTS Widgets)
 
 set(OD_PLUGIN_LIB_SRC
   src/object_detection/detected_objects_display.cpp
+  src/object_detection/detected_objects_with_feature_display.cpp
   src/object_detection/tracked_objects_display.cpp
   src/object_detection/predicted_objects_display.cpp
 )
@@ -17,6 +18,7 @@ set(OD_PLUGIN_LIB_HEADERS
 )
 set(OD_PLUGIN_LIB_HEADERS_TO_WRAP
   include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_display.hpp
+  include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp
   include/autoware_auto_perception_rviz_plugin/object_detection/tracked_objects_display.hpp
   include/autoware_auto_perception_rviz_plugin/object_detection/predicted_objects_display.hpp
 )

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp
@@ -1,0 +1,74 @@
+// Copyright 2021 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN__OBJECT_DETECTION__DETECTED_OBJECTS_WITH_FEATURE_DISPLAY_HPP_
+#define AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN__OBJECT_DETECTION__DETECTED_OBJECTS_WITH_FEATURE_DISPLAY_HPP_
+
+#include "autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp"
+
+#include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
+
+namespace autoware
+{
+namespace rviz_plugins
+{
+namespace object_detection
+{
+/// \brief Class defining rviz plugin to visualize DetectedObjectsWithFeature
+class AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC DetectedObjectsWithFeatureDisplay
+: public ObjectPolygonDisplayBase<tier4_perception_msgs::msg::DetectedObjectsWithFeature>
+{
+  Q_OBJECT
+
+public:
+  using DetectedObjectsWithFeature = tier4_perception_msgs::msg::DetectedObjectsWithFeature;
+
+  DetectedObjectsWithFeatureDisplay();
+
+private:
+  std::optional<Marker::SharedPtr> get_point_cloud_marker_ptr(
+    const sensor_msgs::msg::PointCloud2 & point_cloud, const std_msgs::msg::ColorRGBA & color,
+    const double & scale) const
+  {
+    if (m_display_point_cloud_property.getBool()) {
+      return detail::get_point_cloud_marker_ptr(point_cloud, color, scale);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  double get_scale() { return m_scale_property.getFloat(); }
+  std_msgs::msg::ColorRGBA get_rgba()
+  {
+    QColor color = m_color_property.getColor();
+    std_msgs::msg::ColorRGBA color_rgba;
+    color_rgba.r = color.redF();
+    color_rgba.g = color.greenF();
+    color_rgba.b = color.blueF();
+    color_rgba.a = m_alpha_property.getFloat();
+    return color_rgba;
+  }
+  void processMessage(DetectedObjectsWithFeature::ConstSharedPtr msg) override;
+
+  // Properties to enable/disable and modify point cloud visualization
+  rviz_common::properties::BoolProperty m_display_point_cloud_property;
+  rviz_common::properties::ColorProperty m_color_property;
+  rviz_common::properties::FloatProperty m_alpha_property;
+  rviz_common::properties::FloatProperty m_scale_property;
+};
+
+}  // namespace object_detection
+}  // namespace rviz_plugins
+}  // namespace autoware
+
+#endif  // AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN__OBJECT_DETECTION__DETECTED_OBJECTS_WITH_FEATURE_DISPLAY_HPP_

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp
@@ -39,17 +39,17 @@ private:
   template <typename ClassificationContainerT>
   std::optional<Marker::SharedPtr> get_point_cloud_marker_ptr(
     const sensor_msgs::msg::PointCloud2 & point_cloud, const ClassificationContainerT & labels,
-    const double & scale) const
+    const double & point_size) const
   {
     const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
     if (m_display_point_cloud_property.getBool()) {
-      return detail::get_point_cloud_marker_ptr(point_cloud, color_rgba, scale);
+      return detail::get_point_cloud_marker_ptr(point_cloud, color_rgba, point_size);
     } else {
       return std::nullopt;
     }
   }
 
-  double get_scale() { return m_point_size_property.getFloat(); }
+  double get_point_size() { return m_point_size_property.getFloat(); }
   void processMessage(DetectedObjectsWithFeature::ConstSharedPtr msg) override;
 
   // Properties to enable/disable and modify point cloud visualization

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp
@@ -36,35 +36,25 @@ public:
   DetectedObjectsWithFeatureDisplay();
 
 private:
+  template <typename ClassificationContainerT>
   std::optional<Marker::SharedPtr> get_point_cloud_marker_ptr(
-    const sensor_msgs::msg::PointCloud2 & point_cloud, const std_msgs::msg::ColorRGBA & color,
+    const sensor_msgs::msg::PointCloud2 & point_cloud, const ClassificationContainerT & labels,
     const double & scale) const
   {
+    const std_msgs::msg::ColorRGBA color_rgba = get_color_rgba(labels);
     if (m_display_point_cloud_property.getBool()) {
-      return detail::get_point_cloud_marker_ptr(point_cloud, color, scale);
+      return detail::get_point_cloud_marker_ptr(point_cloud, color_rgba, scale);
     } else {
       return std::nullopt;
     }
   }
 
-  double get_scale() { return m_scale_property.getFloat(); }
-  std_msgs::msg::ColorRGBA get_rgba()
-  {
-    QColor color = m_color_property.getColor();
-    std_msgs::msg::ColorRGBA color_rgba;
-    color_rgba.r = color.redF();
-    color_rgba.g = color.greenF();
-    color_rgba.b = color.blueF();
-    color_rgba.a = m_alpha_property.getFloat();
-    return color_rgba;
-  }
+  double get_scale() { return m_point_size_property.getFloat(); }
   void processMessage(DetectedObjectsWithFeature::ConstSharedPtr msg) override;
 
   // Properties to enable/disable and modify point cloud visualization
   rviz_common::properties::BoolProperty m_display_point_cloud_property;
-  rviz_common::properties::ColorProperty m_color_property;
-  rviz_common::properties::FloatProperty m_alpha_property;
-  rviz_common::properties::FloatProperty m_scale_property;
+  rviz_common::properties::FloatProperty m_point_size_property;
 };
 
 }  // namespace object_detection

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -173,14 +173,14 @@ get_path_confidence_marker_ptr(
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
   const std_msgs::msg::ColorRGBA & path_confidence_color);
 
-AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_arc_line_strip(
-  const double start_angle, const double end_angle, const double radius,
-  std::vector<geometry_msgs::msg::Point> & points);
-
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_point_cloud_marker_ptr(
   const sensor_msgs::msg::PointCloud2 & point_cloud, const std_msgs::msg::ColorRGBA & color_rgba,
   const double & scale);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_arc_line_strip(
+  const double start_angle, const double end_angle, const double radius,
+  std::vector<geometry_msgs::msg::Point> & points);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_line_list_from_points(
   const double point_list[][3], const int point_pairs[][2], const int & num_pairs,

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_detail.hpp
@@ -30,6 +30,8 @@
 #include <geometry_msgs/msg/pose_with_covariance.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/twist_with_covariance.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
 #include <algorithm>
@@ -174,6 +176,11 @@ get_path_confidence_marker_ptr(
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_arc_line_strip(
   const double start_angle, const double end_angle, const double radius,
   std::vector<geometry_msgs::msg::Point> & points);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
+get_point_cloud_marker_ptr(
+  const sensor_msgs::msg::PointCloud2 & point_cloud, const std_msgs::msg::ColorRGBA & color_rgba,
+  const double & scale);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_line_list_from_points(
   const double point_list[][3], const int point_pairs[][2], const int & num_pairs,

--- a/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/autoware_auto_perception_rviz_plugin/object_detection/object_polygon_display_base.hpp
@@ -85,11 +85,9 @@ public:
     m_display_path_confidence_property{
       "Display Predicted Path Confidence", true, "Enable/disable predicted paths visualization",
       this},
-
     m_display_existence_probability_property{
       "Display Existence Probability", false, "Enable/disable existence probability visualization",
       this},
-
     m_line_width_property{"Line Width", 0.03, "Line width of object-shape", this},
     m_default_topic{default_topic}
   {

--- a/common/autoware_auto_perception_rviz_plugin/package.xml
+++ b/common/autoware_auto_perception_rviz_plugin/package.xml
@@ -21,6 +21,8 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tier4_perception_msgs</depend>
 
   <exec_depend>libqt5-widgets</exec_depend>
   <exec_depend>rviz2</exec_depend>

--- a/common/autoware_auto_perception_rviz_plugin/plugins_description.xml
+++ b/common/autoware_auto_perception_rviz_plugin/plugins_description.xml
@@ -23,4 +23,11 @@
     <message_type>autoware_auto_perception_msgs/msg/DetectedObjects</message_type>
   </class>
 
+  <class name="autoware_auto_perception_rviz_plugin/DetectedObjectsWithFeature" type="autoware::rviz_plugins::object_detection::DetectedObjectsWithFeatureDisplay" base_class_type="rviz_common::Display">
+    <description>
+            Convert a DetectedObjectsWithFeature to markers and display them.
+    </description>
+    <message_type>tier4_perception_msgs/msg/DetectedObjectsWithFeature</message_type>
+  </class>
+
 </library>

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_with_feature_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_with_feature_display.cpp
@@ -159,7 +159,7 @@ void DetectedObjectsWithFeatureDisplay::processMessage(
     }
     // Get marker for cluster
     auto point_cloud_marker = get_point_cloud_marker_ptr(
-      feature_object.feature.cluster, object.classification, get_scale());
+      feature_object.feature.cluster, object.classification, get_point_size());
     if (point_cloud_marker) {
       auto point_cloud_marker_ptr = point_cloud_marker.value();
       point_cloud_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_with_feature_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_with_feature_display.cpp
@@ -28,10 +28,7 @@ DetectedObjectsWithFeatureDisplay::DetectedObjectsWithFeatureDisplay()
 : ObjectPolygonDisplayBase("detected_objects_with_feature"),
   m_display_point_cloud_property{
     "Display Point Cloud", true, "Enable/disable point cloud visualization", this},
-  m_color_property{"Color", QColor{255, 255, 255}, "Set color value.", this},
-  m_alpha_property{
-    "Alpha", 0.7, "Set point cloud transparency value. Should be between 0 and 1.", this},
-  m_scale_property{"Scale", 0.07, "Set point cloud scale value.", this}
+  m_point_size_property{"Point Size", 0.07, "Set the size of points from the point cloud.", this}
 {
 }
 
@@ -161,8 +158,8 @@ void DetectedObjectsWithFeatureDisplay::processMessage(
       add_marker(marker_ptr);
     }
     // Get marker for cluster
-    auto point_cloud_marker =
-      get_point_cloud_marker_ptr(feature_object.feature.cluster, get_rgba(), get_scale());
+    auto point_cloud_marker = get_point_cloud_marker_ptr(
+      feature_object.feature.cluster, object.classification, get_scale());
     if (point_cloud_marker) {
       auto point_cloud_marker_ptr = point_cloud_marker.value();
       point_cloud_marker_ptr->header = msg->header;

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_with_feature_display.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/detected_objects_with_feature_display.cpp
@@ -1,0 +1,182 @@
+// Copyright 2021 Apex.AI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Co-developed by Tier IV, Inc. and Apex.AI, Inc.
+
+#include "autoware_auto_perception_rviz_plugin/object_detection/detected_objects_with_feature_display.hpp"
+
+#include <memory>
+
+namespace autoware
+{
+namespace rviz_plugins
+{
+namespace object_detection
+{
+DetectedObjectsWithFeatureDisplay::DetectedObjectsWithFeatureDisplay()
+: ObjectPolygonDisplayBase("detected_objects_with_feature"),
+  m_display_point_cloud_property{
+    "Display Point Cloud", true, "Enable/disable point cloud visualization", this},
+  m_color_property{"Color", QColor{255, 255, 255}, "Set color value.", this},
+  m_alpha_property{
+    "Alpha", 0.7, "Set point cloud transparency value. Should be between 0 and 1.", this},
+  m_scale_property{"Scale", 0.07, "Set point cloud scale value.", this}
+{
+}
+
+void DetectedObjectsWithFeatureDisplay::processMessage(
+  DetectedObjectsWithFeature::ConstSharedPtr msg)
+{
+  clear_markers();
+  int id = 0;
+  for (const auto & feature_object : msg->feature_objects) {
+    // Get marker for shape
+    const auto & object = feature_object.object;
+    auto shape_marker = get_shape_marker_ptr(
+      object.shape, object.kinematics.pose_with_covariance.pose.position,
+      object.kinematics.pose_with_covariance.pose.orientation, object.classification,
+      get_line_width(),
+      object.kinematics.orientation_availability ==
+        autoware_auto_perception_msgs::msg::DetectedObjectKinematics::AVAILABLE);
+    if (shape_marker) {
+      auto shape_marker_ptr = shape_marker.value();
+      shape_marker_ptr->header = msg->header;
+      shape_marker_ptr->id = id++;
+      add_marker(shape_marker_ptr);
+    }
+
+    // Get marker for label
+    auto label_marker = get_label_marker_ptr(
+      object.kinematics.pose_with_covariance.pose.position,
+      object.kinematics.pose_with_covariance.pose.orientation, object.classification);
+    if (label_marker) {
+      auto label_marker_ptr = label_marker.value();
+      label_marker_ptr->header = msg->header;
+      label_marker_ptr->id = id++;
+      add_marker(label_marker_ptr);
+    }
+
+    // Get marker for pose covariance
+    auto pose_with_covariance_marker =
+      get_pose_covariance_marker_ptr(object.kinematics.pose_with_covariance);
+    if (pose_with_covariance_marker) {
+      auto marker_ptr = pose_with_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
+    // Get marker for yaw covariance
+    auto yaw_covariance_marker = get_yaw_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.shape.dimensions.x * 0.65,
+      get_line_width() * 0.5);
+    if (yaw_covariance_marker) {
+      auto marker_ptr = yaw_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
+    // Get marker for existence probability
+    geometry_msgs::msg::Point existence_probability_position;
+    existence_probability_position.x = object.kinematics.pose_with_covariance.pose.position.x + 0.5;
+    existence_probability_position.y = object.kinematics.pose_with_covariance.pose.position.y;
+    existence_probability_position.z = object.kinematics.pose_with_covariance.pose.position.z + 0.5;
+    const float existence_probability = object.existence_probability;
+    auto existence_prob_marker = get_existence_probability_marker_ptr(
+      existence_probability_position, object.kinematics.pose_with_covariance.pose.orientation,
+      existence_probability, object.classification);
+    if (existence_prob_marker) {
+      auto existence_prob_marker_ptr = existence_prob_marker.value();
+      existence_prob_marker_ptr->header = msg->header;
+      existence_prob_marker_ptr->id = id++;
+      add_marker(existence_prob_marker_ptr);
+    }
+
+    // Get marker for velocity text
+    geometry_msgs::msg::Point vel_vis_position;
+    vel_vis_position.x = object.kinematics.pose_with_covariance.pose.position.x - 0.5;
+    vel_vis_position.y = object.kinematics.pose_with_covariance.pose.position.y;
+    vel_vis_position.z = object.kinematics.pose_with_covariance.pose.position.z - 0.5;
+    auto velocity_text_marker = get_velocity_text_marker_ptr(
+      object.kinematics.twist_with_covariance.twist, vel_vis_position, object.classification);
+    if (velocity_text_marker) {
+      auto velocity_text_marker_ptr = velocity_text_marker.value();
+      velocity_text_marker_ptr->header = msg->header;
+      velocity_text_marker_ptr->id = id++;
+      add_marker(velocity_text_marker_ptr);
+    }
+
+    // Get marker for twist
+    auto twist_marker = get_twist_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width());
+    if (twist_marker) {
+      auto twist_marker_ptr = twist_marker.value();
+      twist_marker_ptr->header = msg->header;
+      twist_marker_ptr->id = id++;
+      add_marker(twist_marker_ptr);
+    }
+
+    // Get marker for twist covariance
+    auto twist_covariance_marker = get_twist_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance);
+    if (twist_covariance_marker) {
+      auto marker_ptr = twist_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
+    // Get marker for yaw rate
+    auto yaw_rate_marker = get_yaw_rate_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width() * 0.4);
+    if (yaw_rate_marker) {
+      auto marker_ptr = yaw_rate_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+
+    // Get marker for yaw rate covariance
+    auto yaw_rate_covariance_marker = get_yaw_rate_covariance_marker_ptr(
+      object.kinematics.pose_with_covariance, object.kinematics.twist_with_covariance,
+      get_line_width() * 0.3);
+    if (yaw_rate_covariance_marker) {
+      auto marker_ptr = yaw_rate_covariance_marker.value();
+      marker_ptr->header = msg->header;
+      marker_ptr->id = id++;
+      add_marker(marker_ptr);
+    }
+    // Get marker for cluster
+    auto point_cloud_marker =
+      get_point_cloud_marker_ptr(feature_object.feature.cluster, get_rgba(), get_scale());
+    if (point_cloud_marker) {
+      auto point_cloud_marker_ptr = point_cloud_marker.value();
+      point_cloud_marker_ptr->header = msg->header;
+      point_cloud_marker_ptr->id = id++;
+      add_marker(point_cloud_marker_ptr);
+    }
+  }
+}
+
+}  // namespace object_detection
+}  // namespace rviz_plugins
+}  // namespace autoware
+
+// Export the plugin
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
+PLUGINLIB_EXPORT_CLASS(
+  autoware::rviz_plugins::object_detection::DetectedObjectsWithFeatureDisplay, rviz_common::Display)

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -579,6 +579,35 @@ visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
   return marker_ptr;
 }
 
+visualization_msgs::msg::Marker::SharedPtr get_point_cloud_marker_ptr(
+  const sensor_msgs::msg::PointCloud2 & point_cloud, const std_msgs::msg::ColorRGBA & color_rgba,
+  const double & scale)
+{
+  auto marker_ptr = std::make_shared<Marker>();
+  marker_ptr->ns = std::string("point cloud");
+
+  using sensor_msgs::msg::PointCloud2;
+  marker_ptr->type = visualization_msgs::msg::Marker::POINTS;
+  auto x_it = sensor_msgs::PointCloud2ConstIterator<float>(point_cloud, "x");
+  auto y_it = sensor_msgs::PointCloud2ConstIterator<float>(point_cloud, "y");
+  auto z_it = sensor_msgs::PointCloud2ConstIterator<float>(point_cloud, "z");
+
+  for (; x_it != x_it.end(); ++x_it, ++y_it, ++z_it) {
+    geometry_msgs::msg::Point pt;
+    pt.x = *x_it;
+    pt.y = *y_it;
+    pt.z = *z_it;
+    marker_ptr->points.push_back(pt);
+  }
+  marker_ptr->color = color_rgba;
+  marker_ptr->scale.x = scale;
+  marker_ptr->scale.y = scale;
+  marker_ptr->scale.z = scale;
+  marker_ptr->action = visualization_msgs::msg::Marker::ADD;
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.15);
+  return marker_ptr;
+}
+
 void calc_line_list_from_points(
   const double point_list[][3], const int point_pairs[][2], const int & num_pairs,
   std::vector<geometry_msgs::msg::Point> & points)


### PR DESCRIPTION
## Description
Visualization for `tier4_perception_msgs::msg::DetectedObjectsWithFeature` message in `autoware_auto_perception_rviz_plugin`. 
Improvement for perception pipeline visualization allow to visualize point cloud from `DetectedObjectsWithFeature` with ability to toggle point cloud visualization and change point size. Point cloud alpha and colors are derived from object classification settings.  

## Tests performed

Tested manually with ros2 bags and simulation, large amount of data can slow down visualization. Further tests are going to be performed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
